### PR TITLE
Adding support for Nexus ContinuationToken

### DIFF
--- a/integration/check_test.go
+++ b/integration/check_test.go
@@ -3,11 +3,14 @@ package integration_test
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -79,6 +82,9 @@ var _ = Describe("check", func() {
 
 					err = os.Remove(tempFile.Name())
 					Ω(err).ShouldNot(HaveOccurred())
+
+					// Let Nexus time to index for search
+					time.Sleep(1 * time.Second)
 				})
 
 				AfterEach(func() {
@@ -119,6 +125,9 @@ var _ = Describe("check", func() {
 
 					err = os.Remove(tempFile.Name())
 					Ω(err).ShouldNot(HaveOccurred())
+
+					// Let Nexus time to index for search
+					time.Sleep(1 * time.Second)
 				})
 
 				AfterEach(func() {
@@ -163,6 +172,9 @@ var _ = Describe("check", func() {
 
 					err = os.Remove(tempFile.Name())
 					Ω(err).ShouldNot(HaveOccurred())
+
+					// Let Nexus time to index for search
+					time.Sleep(1 * time.Second)
 				})
 
 				AfterEach(func() {
@@ -189,7 +201,7 @@ var _ = Describe("check", func() {
 			})
 
 			Context("with group with glob", func() {
-				Context("with version is group", func() {
+				Context("with version in group", func() {
 					BeforeEach(func() {
 						group = "/files-in-group-that-match/v*"
 						checkRequest.Source.Group = group
@@ -210,6 +222,9 @@ var _ = Describe("check", func() {
 
 						err = os.Remove(tempFile.Name())
 						Ω(err).ShouldNot(HaveOccurred())
+
+						// Let Nexus time to index for search
+						time.Sleep(1 * time.Second)
 					})
 
 					AfterEach(func() {
@@ -234,7 +249,7 @@ var _ = Describe("check", func() {
 						}))
 					})
 				})
-				Context("with version is file", func() {
+				Context("with version in filename", func() {
 					BeforeEach(func() {
 						group = "/files-in-group-that-match/*"
 						checkRequest.Source.Group = group
@@ -255,6 +270,9 @@ var _ = Describe("check", func() {
 
 						err = os.Remove(tempFile.Name())
 						Ω(err).ShouldNot(HaveOccurred())
+
+						// Let Nexus time to index for search
+						time.Sleep(1 * time.Second)
 					})
 
 					AfterEach(func() {
@@ -278,6 +296,398 @@ var _ = Describe("check", func() {
 							},
 						}))
 					})
+				})
+			})
+
+			Context("with group with will use the Continuation Token", func() {
+				var itemCount int
+				BeforeEach(func() {
+					itemCount = 50
+					group = "/files-in-a-large-group-that-match"
+					checkRequest.Source.Group = group
+					checkRequest.Source.Regexp = "files-in-a-large-group-that-match/file-does-match-(.*)"
+
+					err := json.NewEncoder(stdin).Encode(checkRequest)
+					Ω(err).ShouldNot(HaveOccurred())
+
+					tempFile, err := ioutil.TempFile("", "file-to-upload")
+					Ω(err).ShouldNot(HaveOccurred())
+					tempFile.Close()
+
+					for i := 1; i <= itemCount; i++ {
+						err = nexusclient.UploadFile(repository, group, fmt.Sprintf("file-does-match-%d", i), tempFile.Name())
+						Ω(err).ShouldNot(HaveOccurred())
+					}
+
+					err = os.Remove(tempFile.Name())
+					Ω(err).ShouldNot(HaveOccurred())
+
+					// Let Nexus time to index for search
+					time.Sleep(2 * time.Second)
+				})
+
+				AfterEach(func() {
+					for i := 1; i <= itemCount; i++ {
+						err := nexusclient.DeleteFile(repository, filepath.Join(strings.TrimPrefix(group, "/"), fmt.Sprintf("file-does-match-%d", i)))
+						Ω(err).ShouldNot(HaveOccurred())
+					}
+				})
+
+				It("output the path of the latest artifact from the group", func() {
+					reader := bytes.NewBuffer(session.Out.Contents())
+
+					var response check.Response
+					err := json.NewDecoder(reader).Decode(&response)
+					Ω(err).ShouldNot(HaveOccurred())
+
+					Ω(response).Should(Equal(check.Response{
+						{
+							Path: filepath.Join(strings.TrimPrefix(group, "/"), "/file-does-match-"+strconv.Itoa(itemCount)),
+						},
+					}))
+				})
+			})
+
+		})
+	})
+
+	Context("when we provide a previous version", func() {
+		var group string
+		var checkRequest check.Request
+
+		BeforeEach(func() {
+			checkRequest = check.Request{
+				Source: models.Source{
+					URL:        url,
+					Repository: repository,
+					Username:   username,
+					Password:   password,
+				},
+			}
+		})
+
+		Context("with files in the group that do not match", func() {
+			Context("with group with no glob", func() {
+				BeforeEach(func() {
+					group = "/files-in-group-that-do-not-match-with-version"
+
+					checkRequest.Source.Group = group
+					checkRequest.Source.Regexp = "files-in-group-that-do-not-match-with-version/file-does-match-(.*)"
+					checkRequest.Version.Path = "files-in-group-that-do-not-match-with-version/file-does-match-1"
+
+					err := json.NewEncoder(stdin).Encode(checkRequest)
+					Ω(err).ShouldNot(HaveOccurred())
+
+					tempFile, err := ioutil.TempFile("", "file-to-upload")
+					Ω(err).ShouldNot(HaveOccurred())
+					tempFile.Close()
+
+					err = nexusclient.UploadFile(repository, group, "file-does-not-match-1", tempFile.Name())
+					Ω(err).ShouldNot(HaveOccurred())
+
+					err = os.Remove(tempFile.Name())
+					Ω(err).ShouldNot(HaveOccurred())
+
+					// Let Nexus time to index for search
+					time.Sleep(1 * time.Second)
+				})
+
+				AfterEach(func() {
+					err := nexusclient.DeleteFile(repository, filepath.Join(strings.TrimPrefix(group, "/"), "file-does-not-match-1"))
+					Ω(err).ShouldNot(HaveOccurred())
+				})
+
+				It("returns an empty check response", func() {
+					reader := bytes.NewBuffer(session.Out.Contents())
+
+					var response check.Response
+					err := json.NewDecoder(reader).Decode(&response)
+					Ω(err).ShouldNot(HaveOccurred())
+
+					Ω(response).Should(BeEmpty())
+				})
+			})
+
+			Context("with group with glob", func() {
+				BeforeEach(func() {
+					group = "/files-in-group-that-do-not-match-with-version/v*/sub"
+
+					checkRequest.Source.Group = group
+					checkRequest.Source.Regexp = "files-in-group-that-do-not-match-with-version/v(.*)/sub/file-does-match"
+					checkRequest.Version.Path = "files-in-group-that-do-not-match-with-version/v1/sub/file-does-match"
+
+					err := json.NewEncoder(stdin).Encode(checkRequest)
+					Ω(err).ShouldNot(HaveOccurred())
+
+					tempFile, err := ioutil.TempFile("", "file-to-upload")
+					Ω(err).ShouldNot(HaveOccurred())
+					tempFile.Close()
+
+					err = nexusclient.UploadFile(repository, "/files-in-group-that-do-not-match-with-version/v1/sub", "file-does-not-match", tempFile.Name())
+					Ω(err).ShouldNot(HaveOccurred())
+
+					err = nexusclient.UploadFile(repository, "/files-in-group-that-do-not-match-with-version/v2/sub", "file-does-not-match", tempFile.Name())
+					Ω(err).ShouldNot(HaveOccurred())
+
+					err = os.Remove(tempFile.Name())
+					Ω(err).ShouldNot(HaveOccurred())
+
+					// Let Nexus time to index for search
+					time.Sleep(1 * time.Second)
+				})
+
+				AfterEach(func() {
+					err := nexusclient.DeleteFile(repository, "files-in-group-that-do-not-match-with-version/v1/sub/file-does-not-match")
+					Ω(err).ShouldNot(HaveOccurred())
+
+					err = nexusclient.DeleteFile(repository, "files-in-group-that-do-not-match-with-version/v2/sub/file-does-not-match")
+					Ω(err).ShouldNot(HaveOccurred())
+				})
+
+				It("returns an empty check response", func() {
+					reader := bytes.NewBuffer(session.Out.Contents())
+
+					var response check.Response
+					err := json.NewDecoder(reader).Decode(&response)
+					Ω(err).ShouldNot(HaveOccurred())
+
+					Ω(response).Should(BeEmpty())
+				})
+			})
+		})
+
+		Context("with files in the group that match", func() {
+			Context("with group with no glob", func() {
+				BeforeEach(func() {
+					group = "/files-in-group-that-match-with-version"
+					checkRequest.Source.Group = group
+					checkRequest.Source.Regexp = "files-in-group-that-match-with-version/file-does-match-(.*)"
+					checkRequest.Version.Path = "files-in-group-that-match-with-version/file-does-match-2"
+
+					err := json.NewEncoder(stdin).Encode(checkRequest)
+					Ω(err).ShouldNot(HaveOccurred())
+
+					tempFile, err := ioutil.TempFile("", "file-to-upload")
+					Ω(err).ShouldNot(HaveOccurred())
+					tempFile.Close()
+
+					err = nexusclient.UploadFile(repository, group, "file-does-match-2", tempFile.Name())
+					Ω(err).ShouldNot(HaveOccurred())
+
+					err = nexusclient.UploadFile(repository, group, "file-does-match-1", tempFile.Name())
+					Ω(err).ShouldNot(HaveOccurred())
+
+					err = nexusclient.UploadFile(repository, group, "file-does-match-3", tempFile.Name())
+					Ω(err).ShouldNot(HaveOccurred())
+
+					err = os.Remove(tempFile.Name())
+					Ω(err).ShouldNot(HaveOccurred())
+
+					// Let Nexus time to index for search
+					time.Sleep(1 * time.Second)
+				})
+
+				AfterEach(func() {
+					err := nexusclient.DeleteFile(repository, filepath.Join(strings.TrimPrefix(group, "/"), "file-does-match-1"))
+					Ω(err).ShouldNot(HaveOccurred())
+
+					err = nexusclient.DeleteFile(repository, filepath.Join(strings.TrimPrefix(group, "/"), "file-does-match-2"))
+					Ω(err).ShouldNot(HaveOccurred())
+
+					err = nexusclient.DeleteFile(repository, filepath.Join(strings.TrimPrefix(group, "/"), "file-does-match-3"))
+					Ω(err).ShouldNot(HaveOccurred())
+				})
+
+				It("output the path of the latest artifact from the group", func() {
+					reader := bytes.NewBuffer(session.Out.Contents())
+
+					var response check.Response
+					err := json.NewDecoder(reader).Decode(&response)
+					Ω(err).ShouldNot(HaveOccurred())
+
+					Ω(response).Should(Equal(check.Response{
+						{
+							Path: filepath.Join(strings.TrimPrefix(group, "/"), "/file-does-match-2"),
+						},
+						{
+							Path: filepath.Join(strings.TrimPrefix(group, "/"), "/file-does-match-3"),
+						},
+					}))
+				})
+			})
+
+			Context("with group with glob", func() {
+				Context("with version in group", func() {
+					BeforeEach(func() {
+						group = "/files-in-group-that-match-with-version/v*"
+						checkRequest.Source.Group = group
+						checkRequest.Source.Regexp = "files-in-group-that-match-with-version/v(.*)/file-does-match"
+						checkRequest.Version.Path = "files-in-group-that-match-with-version/v2/file-does-match"
+
+						err := json.NewEncoder(stdin).Encode(checkRequest)
+						Ω(err).ShouldNot(HaveOccurred())
+
+						tempFile, err := ioutil.TempFile("", "file-to-upload")
+						Ω(err).ShouldNot(HaveOccurred())
+						tempFile.Close()
+
+						err = nexusclient.UploadFile(repository, "/files-in-group-that-match-with-version/v2", "file-does-match", tempFile.Name())
+						Ω(err).ShouldNot(HaveOccurred())
+
+						err = nexusclient.UploadFile(repository, "/files-in-group-that-match-with-version/v1", "file-does-match", tempFile.Name())
+						Ω(err).ShouldNot(HaveOccurred())
+
+						err = nexusclient.UploadFile(repository, "/files-in-group-that-match-with-version/v3", "file-does-match", tempFile.Name())
+						Ω(err).ShouldNot(HaveOccurred())
+
+						err = os.Remove(tempFile.Name())
+						Ω(err).ShouldNot(HaveOccurred())
+
+						// Let Nexus time to index for search
+						time.Sleep(1 * time.Second)
+					})
+
+					AfterEach(func() {
+						err := nexusclient.DeleteFile(repository, "files-in-group-that-match-with-version/v1/file-does-match")
+						Ω(err).ShouldNot(HaveOccurred())
+
+						err = nexusclient.DeleteFile(repository, "files-in-group-that-match-with-version/v2/file-does-match")
+						Ω(err).ShouldNot(HaveOccurred())
+
+						err = nexusclient.DeleteFile(repository, "files-in-group-that-match-with-version/v3/file-does-match")
+						Ω(err).ShouldNot(HaveOccurred())
+					})
+
+					It("output the path of the latest artifact from the group", func() {
+						reader := bytes.NewBuffer(session.Out.Contents())
+
+						var response check.Response
+						err := json.NewDecoder(reader).Decode(&response)
+						Ω(err).ShouldNot(HaveOccurred())
+
+						Ω(response).Should(Equal(check.Response{
+							{
+								Path: "files-in-group-that-match-with-version/v2/file-does-match",
+							},
+							{
+								Path: "files-in-group-that-match-with-version/v3/file-does-match",
+							},
+						}))
+					})
+				})
+				Context("with version in filename", func() {
+					BeforeEach(func() {
+						group = "/files-in-group-that-match-with-version/*"
+						checkRequest.Source.Group = group
+						checkRequest.Source.Regexp = "files-in-group-that-match-with-version/.*/file-does-match-(.*)"
+						checkRequest.Version.Path = "files-in-group-that-match-with-version/4/file-does-match-2"
+
+						err := json.NewEncoder(stdin).Encode(checkRequest)
+						Ω(err).ShouldNot(HaveOccurred())
+
+						tempFile, err := ioutil.TempFile("", "file-to-upload")
+						Ω(err).ShouldNot(HaveOccurred())
+						tempFile.Close()
+
+						err = nexusclient.UploadFile(repository, "/files-in-group-that-match-with-version/3", "file-does-match-1", tempFile.Name())
+						Ω(err).ShouldNot(HaveOccurred())
+
+						err = nexusclient.UploadFile(repository, "/files-in-group-that-match-with-version/4", "file-does-match-2", tempFile.Name())
+						Ω(err).ShouldNot(HaveOccurred())
+
+						err = nexusclient.UploadFile(repository, "/files-in-group-that-match-with-version/5", "file-does-match-3", tempFile.Name())
+						Ω(err).ShouldNot(HaveOccurred())
+
+						err = os.Remove(tempFile.Name())
+						Ω(err).ShouldNot(HaveOccurred())
+
+						// Let Nexus time to index for search
+						time.Sleep(1 * time.Second)
+					})
+
+					AfterEach(func() {
+						err := nexusclient.DeleteFile(repository, "files-in-group-that-match-with-version/3/file-does-match-1")
+						Ω(err).ShouldNot(HaveOccurred())
+
+						err = nexusclient.DeleteFile(repository, "files-in-group-that-match-with-version/4/file-does-match-2")
+						Ω(err).ShouldNot(HaveOccurred())
+
+						err = nexusclient.DeleteFile(repository, "files-in-group-that-match-with-version/5/file-does-match-3")
+						Ω(err).ShouldNot(HaveOccurred())
+					})
+
+					It("output the path of the latest artifact from the group", func() {
+						reader := bytes.NewBuffer(session.Out.Contents())
+
+						var response check.Response
+						err := json.NewDecoder(reader).Decode(&response)
+						Ω(err).ShouldNot(HaveOccurred())
+
+						Ω(response).Should(Equal(check.Response{
+							{
+								Path: "files-in-group-that-match-with-version/4/file-does-match-2",
+							},
+							{
+								Path: "files-in-group-that-match-with-version/5/file-does-match-3",
+							},
+						}))
+					})
+				})
+			})
+
+			Context("with group with will use the Continuation Token", func() {
+				var itemCount int
+				BeforeEach(func() {
+					itemCount = 50
+					group = "/files-in-a-large-group-that-match-with-version"
+					checkRequest.Source.Group = group
+					checkRequest.Source.Regexp = "files-in-a-large-group-that-match-with-version/file-does-match-(.*)"
+					checkRequest.Version.Path = "files-in-a-large-group-that-match-with-version/file-does-match-48"
+
+					err := json.NewEncoder(stdin).Encode(checkRequest)
+					Ω(err).ShouldNot(HaveOccurred())
+
+					tempFile, err := ioutil.TempFile("", "file-to-upload")
+					Ω(err).ShouldNot(HaveOccurred())
+					tempFile.Close()
+
+					for i := 1; i <= itemCount; i++ {
+						err = nexusclient.UploadFile(repository, group, fmt.Sprintf("file-does-match-%d", i), tempFile.Name())
+						Ω(err).ShouldNot(HaveOccurred())
+					}
+
+					err = os.Remove(tempFile.Name())
+					Ω(err).ShouldNot(HaveOccurred())
+
+					// Let Nexus time to index for search
+					time.Sleep(2 * time.Second)
+				})
+
+				AfterEach(func() {
+					for i := 1; i <= itemCount; i++ {
+						err := nexusclient.DeleteFile(repository, filepath.Join(strings.TrimPrefix(group, "/"), fmt.Sprintf("file-does-match-%d", i)))
+						Ω(err).ShouldNot(HaveOccurred())
+					}
+				})
+
+				It("output the path of the latest artifact from the group", func() {
+					reader := bytes.NewBuffer(session.Out.Contents())
+
+					var response check.Response
+					err := json.NewDecoder(reader).Decode(&response)
+					Ω(err).ShouldNot(HaveOccurred())
+
+					Ω(response).Should(Equal(check.Response{
+						{
+							Path: filepath.Join(strings.TrimPrefix(group, "/"), "/file-does-match-48"),
+						},
+						{
+							Path: filepath.Join(strings.TrimPrefix(group, "/"), "/file-does-match-49"),
+						},
+						{
+							Path: filepath.Join(strings.TrimPrefix(group, "/"), "/file-does-match-50"),
+						},
+					}))
 				})
 			})
 

--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -84,7 +84,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 
 var _ = BeforeEach(func() {
 	if nexusclient == nil {
-		Skip("Environment variables need to be set for Nexus integration")
+		Skip("Environment variables need to be set for running integration tests")
 	}
 })
 

--- a/integration/nexusclient_test.go
+++ b/integration/nexusclient_test.go
@@ -60,6 +60,9 @@ var _ = Describe("Nexuxclient", func() {
 		err = nexusclient.UploadFile(repository, groupPrefix, "file-to-upload-3", tempFile.Name())
 		Ω(err).ShouldNot(HaveOccurred())
 
+		// Let Nexus time to index for search
+		time.Sleep(1 * time.Second)
+
 		paths, err := nexusclient.ListFiles(repository, groupPrefix)
 		Ω(err).ShouldNot(HaveOccurred())
 

--- a/integration/out_test.go
+++ b/integration/out_test.go
@@ -4,10 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"io/ioutil"
+	neturl "net/url"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -84,6 +87,9 @@ var _ = Describe("out", func() {
 		})
 
 		It("uploads the file to the correct bucket and outputs the version", func() {
+			// Let Nexus time to index for search
+			time.Sleep(2 * time.Second)
+
 			nexuspaths, err := nexusclient.ListFiles(repository, groupPrefix)
 			Ω(err).ShouldNot(HaveOccurred())
 
@@ -94,6 +100,9 @@ var _ = Describe("out", func() {
 			var response out.Response
 			err = json.NewDecoder(reader).Decode(&response)
 			Ω(err).ShouldNot(HaveOccurred())
+
+			u, _ := neturl.Parse(url)
+			u.Path = path.Join(u.Path, "repository", repository, "out-request-files/glob-file-to-upload")
 
 			Ω(response).Should(Equal(out.Response{
 				Version: models.Version{
@@ -106,7 +115,7 @@ var _ = Describe("out", func() {
 					},
 					{
 						Name:  "url",
-						Value: url + "/repository/" + repository + "/out-request-files/glob-file-to-upload",
+						Value: u.String(),
 					},
 				},
 			}))

--- a/models/models.go
+++ b/models/models.go
@@ -54,7 +54,8 @@ type MetadataPair struct {
 
 // RespositoryItems struct is a collection of RepositoryItems
 type RespositoryItems struct {
-	Items []RepositoryItem `json:"items"`
+	Items             []RepositoryItem `json:"items"`
+	ContinuationToken string           `json:"continuationToken"`
 }
 
 // RepositoryItem struct represent a Component in Nexus


### PR DESCRIPTION
Additional changes:
- Added missing integration test for Check command when a previous
version is provided
- Change NexusClient URL method to generate it and not fetch it from
Nexus to make it faster
- Removed automatic sleep in NexusClient.UploadFile, sleep added back
where required in integration tests

Fixes: #13 