### PR TITLE
Adding Release Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,11 +39,6 @@ jobs:
     - name: Generate fakes for testing
       run: go generate ./...
 
-    - name: Sleep to let Nexus start
-      uses: jakejarvis/wait-action@master
-      with:
-        time: '60s'
-
     - name: Run tests
       run: go test ./...
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+on:
+  push:
+    tags:
+      - 'v*'
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repo
+      uses: actions/checkout@v2
+    - name: Build and Publish to DockerHub
+      uses: docker/build-push-action@v1
+      with:
+        repository: trecnoc/nexus3-resource
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        tags_with_ref: true
+    - name: Create GitHub Release
+      uses: actions/create-release@latest
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: false


### PR DESCRIPTION
Triggers when v* tags are created, will build and push the Dockerfile to
DockerHub and create the GitHub release.

Also removed the sleep in the CI workflow which shouldn't be required
since our custom images reports healthy only when ready.

Fixes: #8 