### PR TITLE
Add Source.Timeout for the Nexus Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ filenames to identify version numbers.
   Semantic versions, or just numbers, are supported. Accordingly, full regular
   expressions are supported, to specify the capture groups.
 
+* `timeout`: *Optional defaults to `10`.* Timeout for the internal HTTP Client in
+  seconds.
+
 * `debug`: *Optional defaults to `false`.* Debug flag for enabling logging and
   request file output in `/tmp`.
 

--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -19,7 +19,7 @@ func main() {
 		ioutil.WriteFile("/tmp/concourse-nexus-request.json", jsonString, os.ModePerm)
 	}
 
-	client := nexusresource.NewNexusClient(request.Source.URL, request.Source.Username, request.Source.Password, request.Source.Debug)
+	client := nexusresource.NewNexusClient(request.Source.URL, request.Source.Username, request.Source.Password, request.Source.Timeout, request.Source.Debug)
 
 	command := check.NewCommand(client)
 	response, err := command.Run(request)

--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -26,7 +26,7 @@ func main() {
 		ioutil.WriteFile("/tmp/concourse-nexus-request.json", jsonString, os.ModePerm)
 	}
 
-	client := nexusresource.NewNexusClient(request.Source.URL, request.Source.Username, request.Source.Password, request.Source.Debug)
+	client := nexusresource.NewNexusClient(request.Source.URL, request.Source.Username, request.Source.Password, request.Source.Timeout, request.Source.Debug)
 
 	command := in.NewCommand(client)
 	response, err := command.Run(destinationDir, request)

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -26,7 +26,7 @@ func main() {
 
 	sourceDir := os.Args[1]
 
-	client := nexusresource.NewNexusClient(request.Source.URL, request.Source.Username, request.Source.Password, request.Source.Debug)
+	client := nexusresource.NewNexusClient(request.Source.URL, request.Source.Username, request.Source.Password, request.Source.Timeout, request.Source.Debug)
 
 	command := out.NewCommand(os.Stderr, client)
 	response, err := command.Run(sourceDir, request)

--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -21,6 +21,7 @@ var url = os.Getenv("NEXUS_TESTING_URL")
 var username = os.Getenv("NEXUS_TESTING_USERNAME")
 var password = os.Getenv("NEXUS_TESTING_PASSWORD")
 var repository = os.Getenv("NEXUS_TESTING_REPOSITORY")
+var timeout = os.Getenv("NEXUS_TESTING_TIMEOUT")
 var debug = os.Getenv("NEXUS_TESTING_DEBUG")
 
 var nexusclient nexusresource.NexusClient
@@ -74,12 +75,17 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		Ω(password).ShouldNot(BeEmpty(), "must specify $NEXUS_TESTING_PASSWORD")
 		Ω(repository).ShouldNot(BeEmpty(), "must specify $NEXUS_TESTING_REPOSITORY")
 
-		debugbool, err := strconv.ParseBool(debug)
+		timeoutInt, err := strconv.Atoi(timeout)
 		if err != nil {
-			debugbool = false
+			timeoutInt = 0
 		}
 
-		nexusclient = nexusresource.NewNexusClient(url, username, password, debugbool)
+		debugBool, err := strconv.ParseBool(debug)
+		if err != nil {
+			debugBool = false
+		}
+
+		nexusclient = nexusresource.NewNexusClient(url, username, password, timeoutInt, debugBool)
 	}
 })
 

--- a/models/models.go
+++ b/models/models.go
@@ -10,6 +10,7 @@ type Source struct {
 	Password   string `json:"password"`
 	Group      string `json:"group"`
 	Regexp     string `json:"regexp"`
+	Timeout    int    `json:"timeout"`
 	Debug      bool   `json:"debug"`
 }
 

--- a/nexusClient.go
+++ b/nexusClient.go
@@ -38,9 +38,14 @@ type nexusclient struct {
 }
 
 // NewNexusClient creates and returns an NexusClient
-func NewNexusClient(nexusURL string, username string, password string, debug bool) NexusClient {
+func NewNexusClient(nexusURL string, username string, password string, timeout int, debug bool) NexusClient {
+	// Set a default timeout
+	if timeout == 0 {
+		timeout = 10
+	}
+
 	httpClient := &http.Client{
-		Timeout: 10 * time.Second,
+		Timeout: time.Duration(timeout) * time.Second,
 	}
 
 	var logger = utils.NewLogger(debug)


### PR DESCRIPTION
Some request might be long, for example downloading/uploading large 
artifacts. With this we will be able to set a longuer timeout.

Fixes #23 